### PR TITLE
Fix image URLs

### DIFF
--- a/blog_posts/90.md
+++ b/blog_posts/90.md
@@ -35,7 +35,7 @@ In Xcode, go to File > New > New File… (Command-N). On the left, select Cocoa 
 
 *New File Picker*
 
-![New File File](../image_resources/xcode-name-new-file.png)
+![New File File](../image_resources/ios-name-new-file.png)
 
 *Name new file*
 

--- a/blog_posts/98.md
+++ b/blog_posts/98.md
@@ -6,7 +6,7 @@ The iOS platform includes a powerful API that lets you directly draw content to 
 
 From Apple's official documentation, "Quartz 2-D is an advanced, two-dimensional drawing engine available for iOS application development…. Quartz 2-D provides low-level, lightweight 2-D rendering with unmatched output fidelity regardless of display or printing device. Quartz 2-D is resolution- and device-independent; you don't need to think about the final destination when you are using the Quartz 2-D…API for drawing." We will talk about what this actually means throughout the course of this article. 
 
-![Stocks app: Custom drawing](../image_resources/stocks-app-custom-drawing.png)
+![Stocks app: Custom drawing](../image_resources/stocks-app-custom-drawing.jpg)
 
 *Stocks app: Custom drawing*
 


### PR DESCRIPTION
An image referenced in [Post #98](https://uroboro.github.io/Learn-Objective-C-in-24-Days-Clone/blog_posts/98.html) references an image as a PNG that is actually a JPG.

An image referenced in [Post #90](https://uroboro.github.io/Learn-Objective-C-in-24-Days-Clone/blog_posts/90.html) references an image named xcode-name-new-file.png, but it is actually named ios-name-new-file.png.